### PR TITLE
Switch to using `percentage` instead of `speed`

### DIFF
--- a/src/controllers/fan-controller.ts
+++ b/src/controllers/fan-controller.ts
@@ -44,7 +44,7 @@ export class FanController extends Controller {
   }
 
   get hasSlider(): boolean {
-    return 'speed' in this.stateObj.attributes;
+    return 'percentage' in this.stateObj.attributes;
   }
 
   get _max(): number {


### PR DESCRIPTION
`speed` was removed in Home Assistant 2022.04. This fixes control of fans.